### PR TITLE
Formatted textfield

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,13 @@
         <jetty.version>9.4.44.v20210927</jetty.version>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>vaadin-addons</id>
+            <url>http://maven.vaadin.com/vaadin-addons</url>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -39,6 +46,12 @@
             <groupId>com.vaadin</groupId>
             <!-- Replace artifactId with vaadin-core to use only free components -->
             <artifactId>vaadin</artifactId>
+        </dependency>
+
+        <dependency>
+           <groupId>org.vaadin</groupId>
+           <artifactId>textfieldformatter</artifactId>
+           <version>5.3.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/hu/kits/wallet/infrastructure/web/ui/FormattedStringToIntegerConverter.java
+++ b/src/main/java/hu/kits/wallet/infrastructure/web/ui/FormattedStringToIntegerConverter.java
@@ -1,0 +1,29 @@
+package hu.kits.wallet.infrastructure.web.ui;
+
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+import com.vaadin.flow.data.converter.StringToIntegerConverter;
+
+public class FormattedStringToIntegerConverter extends StringToIntegerConverter {
+
+    public static final char NUMBER_GROUPING_SEPARATOR = ' ';
+    
+    private final DecimalFormat format;
+    
+    public FormattedStringToIntegerConverter() {
+        super("Nem szám");
+        DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols();
+        decimalFormatSymbols.setGroupingSeparator(NUMBER_GROUPING_SEPARATOR);
+        format = new DecimalFormat("###,###", decimalFormatSymbols);
+        format.setMinimumIntegerDigits(1);
+    }
+    
+    @Override
+    protected NumberFormat getFormat(Locale locale) {
+        return format;
+    }
+
+}

--- a/src/main/java/hu/kits/wallet/infrastructure/web/ui/PurchaseData.java
+++ b/src/main/java/hu/kits/wallet/infrastructure/web/ui/PurchaseData.java
@@ -12,7 +12,7 @@ public class PurchaseData {
 
     private Account account;
     private LocalDate date;
-    private double amount;
+    private int amount;
     private Category category;
     private String shop;
     private String subject;
@@ -58,11 +58,11 @@ public class PurchaseData {
         this.date = date;
     }
     
-    public double getAmount() {
+    public int getAmount() {
         return amount;
     }
     
-    public void setAmount(double amount) {
+    public void setAmount(int amount) {
         this.amount = amount;
     }
     

--- a/src/main/java/hu/kits/wallet/infrastructure/web/ui/PurchaseView.java
+++ b/src/main/java/hu/kits/wallet/infrastructure/web/ui/PurchaseView.java
@@ -98,7 +98,7 @@ public class PurchaseView extends VerticalLayout implements HasUrlParameter<Long
         binder.forField(accountCombo).asRequired("Nem lehet üres").bind("account");
         binder.forField(amountField).asRequired("Nem lehet üres").bind("amount");
         binder.forField(commentField).bind("comment");
-        binder.forField(photosComponent).bind("photos");
+        binder.forField(photosComponent).bind("files");
         
     }
     

--- a/src/main/java/hu/kits/wallet/infrastructure/web/ui/PurchaseView.java
+++ b/src/main/java/hu/kits/wallet/infrastructure/web/ui/PurchaseView.java
@@ -5,6 +5,7 @@ import java.time.temporal.ChronoUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.vaadin.textfieldformatter.NumeralFieldFormatter;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
@@ -12,12 +13,13 @@ import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.IronIcon;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.notification.Notification.Position;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.flow.component.textfield.TextArea;
+import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.BeforeEvent;
 import com.vaadin.flow.router.HasUrlParameter;
@@ -43,7 +45,7 @@ public class PurchaseView extends VerticalLayout implements HasUrlParameter<Long
     private final ComboBox<String> subjectCombo = new ComboBox<>("Tárgy");
     private final ComboBox<Category> categoryCombo = new ComboBox<>("Kategória", Category.values());
     private final ComboBox<Account> accountCombo = new ComboBox<>("Account", Account.values());
-    private final NumberField amountField = new NumberField("Összeg");
+    private final TextField amountField = new TextField("Összeg");
     private final TextArea commentField = new TextArea("Megjegyzés");
     private final PhotosComponent photosComponent = new PhotosComponent("Fényképek");
     private final Div lastPurchaseForShopLabel = new Div();
@@ -96,10 +98,13 @@ public class PurchaseView extends VerticalLayout implements HasUrlParameter<Long
         binder.forField(subjectCombo).asRequired("Nem lehet üres").bind("subject");
         binder.forField(categoryCombo).asRequired("Nem lehet üres").bind("category");
         binder.forField(accountCombo).asRequired("Nem lehet üres").bind("account");
-        binder.forField(amountField).asRequired("Nem lehet üres").bind("amount");
         binder.forField(commentField).bind("comment");
         binder.forField(photosComponent).bind("files");
         
+        binder.forField(amountField)
+            .withConverter(new FormattedStringToIntegerConverter())
+            .asRequired("Nem lehet üres")
+            .bind("amount");
     }
     
     private void save() {
@@ -147,7 +152,7 @@ public class PurchaseView extends VerticalLayout implements HasUrlParameter<Long
         accountCombo.setValue(purchases.finAccount(shop));
         categoryCombo.setValue(purchases.findCategory(shop));
         subjectCombo.setValue(purchases.findMostCommonSubjectFor(shop));
-        amountField.setValue((double)purchases.findMostCommonAmountFor(shop));
+        amountField.setValue(String.valueOf(purchases.findMostCommonAmountFor(shop)));
     }
     
     private static PurchaseRepository purchaseRepository() {
@@ -158,8 +163,10 @@ public class PurchaseView extends VerticalLayout implements HasUrlParameter<Long
         setDefaultHorizontalComponentAlignment(Alignment.STRETCH);
         setSpacing(false);
         
+        new NumeralFieldFormatter(String.valueOf(FormattedStringToIntegerConverter.NUMBER_GROUPING_SEPARATOR), ".", 0).extend(amountField);
+        amountField.setLabel("Összeg");
         amountField.setWidth("150px");
-        amountField.setPattern("[0-9]*");
+        //amountField.setPattern("[0-9]*");
         amountField.setPreventInvalidInput(true);
         amountField.setSuffixComponent(new Span("Ft"));
         amountField.setClearButtonVisible(true);


### PR DESCRIPTION
Use formatting in a number field is not straightforward.
The vaadin NumberField component does not accept any formatting, so it display numbers like this: 1000000 instead of 1 000 000 
To be able to use formatting I had to switch to TextField. But it requires a converter **StringToIntegerConverter**. But it still displays the number without formatting when we enter the number, so I had to use a third party component **NumeralFieldFormatter**. But I had to write my own StringToIntegerConverter to be able to work with the NumeralFieldFormatter.
But now on mobile it does not show the number pad when entering the amount, but removing `amountField.setPreventInvalidInput(true); `fixed the issue.